### PR TITLE
imported Tuple, modified other tuple -> Tuple

### DIFF
--- a/S15lib/g2lib/g2lib.py
+++ b/S15lib/g2lib/g2lib.py
@@ -3,7 +3,7 @@
 import typing
 import warnings
 from dataclasses import dataclass
-from typing import List, Optional, Union, Tuple
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import pyximport

--- a/S15lib/g2lib/g2lib.py
+++ b/S15lib/g2lib/g2lib.py
@@ -3,7 +3,7 @@
 import typing
 import warnings
 from dataclasses import dataclass
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Tuple
 
 import numpy as np
 import pyximport
@@ -357,11 +357,11 @@ class PeakStatistics:
 def histogram(
     alice: list,
     bob: list,
-    duration: Union[float, tuple[float, float]],
+    duration: Union[float, Tuple[float, float]],
     resolution: float = 1,
     center: float = 0.0,
     statistics: bool = False,
-    window: Optional[Union[float, tuple[float, float]]] = None,
+    window: Optional[Union[float, Tuple[float, float]]] = None,
 ):
     """Returns the coincidence histogram and corresponding (left-edge) bin timings.
 


### PR DESCRIPTION
Code was throwing a type error when I tried to run TDC's GUI page. Upon some looking into we discovered that the code in g2lib as such may cause an issue for Python 3.9+ users because there was a clash between two classes defined as 'tuple'

When we modified the code to import Tuple from 'typing' library , and adjusted the other 'tuple's to 'Tuple' it worked like a charm. 