### PR TITLE
Fixed integration time setting in TDC1 class

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 
 requirements = [
-    "psutils",
+    "psutil",
     "pyserial",
     "numpy",
 ]


### PR DESCRIPTION
Moved 0 integration time out of int_time property since doesn't make sense in counter mode. Moved integration time for timestamp mode back into get_timestamp