### PR TITLE
Remove deprecated distutils and np.int_t

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Compiled library files
 S15lib/g2lib/delta.so
+build/
 
 # Virtual environments
 venv/

--- a/S15lib/g2lib/delta.pyx
+++ b/S15lib/g2lib/delta.pyx
@@ -4,7 +4,6 @@ cimport numpy as np
 
 # distutils: define_macros=NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION
 DTYPE = np.int64
-ctypedef np.int_t DTYPE_t
 
 @cython.boundscheck(False)  # turn off bounds-checking
 @cython.wraparound(False)   # turn off negative index wrapping

--- a/S15lib/g2lib/setup.py
+++ b/S15lib/g2lib/setup.py
@@ -1,7 +1,6 @@
-from setuptools import Extension, setup
-
 import numpy as np
 from Cython.Build import cythonize
+from setuptools import Extension, setup
 
 package = Extension(
     name="delta",

--- a/S15lib/g2lib/setup.py
+++ b/S15lib/g2lib/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import Extension, setup
+from setuptools import Extension, setup
 
 import numpy as np
 from Cython.Build import cythonize


### PR DESCRIPTION
Tested library in Python 3.12.4 with numpy 2.0.0. The distutils library has been formally removed from 3.12, and is officially superseded by setuptools a while ago. A direct change should be okay since this method of compiling g2lib.delta_loop using g2lib/setup.py is not officially documented.

Cython specific np.int_t has also been dropped, but this was not used anywhere in the g2lib code anyway.