### PR TITLE
Fix default compiler search to use preferred linker flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ S15lib is a Python package for controlling [S-Fifteen instruments](https://s-fif
 Install the package directly with
 
 ```
+# For Linux/MacOS
 pip install git+https://github.com/s-fifteen-instruments/pyS15.git
+
+# For Windows and/or systems with compile-related installation difficulties
+pip install git+https://github.com/s-fifteen-instruments/pyS15.git@no_compile
 ```
 
 Alternatively, clone or [download](https://github.com/s-fifteen-instruments/pyS15/archive/refs/heads/master.zip)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 import shutil
 import sysconfig
 
@@ -26,16 +27,60 @@ requirements_apps = [
 #
 # Precedence:
 #   1. User environment variable, e.g. CC=gcc
-#   2. OS executable in PATH, e.g. /usr/bin/cc
-#   3. Python build-time compiler
+#   2. Python build-time compiler
+#   3. OS executable in PATH, e.g. /usr/bin/cc
+#
+# TODO: Check if compatible with Windows installations
 config = sysconfig.get_config_vars()
-cc = os.environ.get("CC", shutil.which("cc"))
-if cc is not None:
-    config["CC"] = cc
-    config["LDSHARED"] = f"{cc} -shared"  # for shared libraries
-ldshared = os.environ.get("LDSHARED", None)  # allow user override
-if ldshared is not None:
-    config["LDSHARED"] = ldshared
+
+# Check if Python was cross-compiled (i.e. build-time compiler does not exist)
+def tokenize(command):  # noqa
+    return shlex.split(command)
+
+
+def get_executable_index(tokens, check_exists=True):
+    for i, token in enumerate(tokens):
+        # Ignore environment variables, and check executable exists
+        if "=" not in token:
+            if check_exists and not shutil.which(token):
+                continue
+            return i
+    else:
+        return None
+
+
+def replace_executable(target, command):
+    tokens = tokenize(command)
+    idx = get_executable_index(tokens, check_exists=False)
+    tokens = list(tokens)  # replace with mutable container
+    tokens[idx] = target
+    return shlex.join(tokens)
+
+
+def find_executable(command):
+    tokens = tokenize(command)
+    idx = get_executable_index(tokens)
+    return idx is not None
+
+
+u_cc = os.environ.get("CC", None)  # user-specified compiler
+if u_cc is not None:
+    config["CC"] = u_cc
+    config["LDSHARED"] = f"{u_cc} -shared"  # for shared libraries
+    u_ldshared = os.environ.get("LDSHARED", None)
+    if u_ldshared is not None:
+        config["LDSHARED"] = u_ldshared  # if manual library linking required
+
+else:
+    b_cc = config.get("CC", None)  # build compiler
+    b_ldshared = config.get("LDSHARED", None)
+    p_cc = shutil.which("cc")  # platform default compiler (w/o options)
+    if b_cc is None:
+        config["CC"] = p_cc
+        config["LDSHARED"] = f"{p_cc} -shared"
+    elif not find_executable(b_cc):
+        config["CC"] = replace_executable(p_cc, b_cc)
+        config["LDSHARED"] = replace_executable(p_cc, b_ldshared)
 
 
 # setuptools project configuration


### PR DESCRIPTION
Fixes #22. For systems which do not require compilation of `g2lib`, a separate [no_compile](https://github.com/s-fifteen-instruments/pyS15/tree/no_compile) branch is provided that would ideally maintain parity with the `master` branch. Documentation updated to reflect these new installation instructions.

----

The compilation step so far has only been tested on Unix-like environments, i.e. might not work for Windows environments where the C compiler typically needs to be separately bootstrapped via MSVC/Cygwin/MinGW.

Marking the compilation step is rather difficult, since it has to pass through both `pip` and `setup.py` as arguments. This behavior is not standard since for wheels, `pip` does not even run any user-supplied code since the compilation is performed during package-time.

An alternative is to issue wheels for each release, but probably introduces unnecessary maintenance and requires setting up a new CI workflow.