### PR TITLE
Ignore rollover events for TDC2 fast mode

### DIFF
--- a/S15lib/g2lib/parse_timestamps.py
+++ b/S15lib/g2lib/parse_timestamps.py
@@ -34,7 +34,7 @@ import numpy as np
 TIMESTAMP_RESOLUTION = 256  # units of 1/ns
 
 
-def print_a1(filename: str, legacy: bool = False):
+def print_a1(filename: str, legacy: bool = False, **kwargs):
     high_pos = 1
     low_pos = 0
     if legacy:
@@ -43,10 +43,10 @@ def print_a1(filename: str, legacy: bool = False):
         data = np.fromfile(file=f, dtype="=I").reshape(-1, 2)
     events = (np.uint64(data[:, high_pos]) << 32) + (data[:, low_pos])
     for event in events:
-        print(f"{event:064b}")
+        print(f"{event:064b}")  # noqa: E231
 
 
-def read_a0(filename: str, legacy=None):
+def read_a0(filename: str, legacy=None, **kwargs):
     data = np.genfromtxt(filename, delimiter="\n", dtype="U8")
     data = np.array([int(v, 16) for v in data]).reshape(-1, 2)
     t = ((np.uint64(data[:, 1]) << 22) + (data[:, 0] >> 10)) / TIMESTAMP_RESOLUTION
@@ -54,7 +54,7 @@ def read_a0(filename: str, legacy=None):
     return t, p
 
 
-def read_a1(filename: str, legacy: bool = False):
+def read_a1(filename: str, legacy: bool = False, **kwargs):
     high_pos = 1
     low_pos = 0
     if legacy:
@@ -68,7 +68,7 @@ def read_a1(filename: str, legacy: bool = False):
     return t, p
 
 
-def read_a2(filename: str, legacy=None):
+def read_a2(filename: str, legacy=None, **kwargs):
     data = np.genfromtxt(filename, delimiter="\n", dtype="U16")
     data = np.array([int(v, 16) for v in data])
     t = (np.uint64(data >> 10)) / TIMESTAMP_RESOLUTION
@@ -84,24 +84,24 @@ def _consolidate_events(t: list, p: list):
     return np.sort(data)
 
 
-def write_a2(filename: str, t: list, p: list, legacy=None):
+def write_a2(filename: str, t: list, p: list, legacy=None, **kwargs):
     data = _consolidate_events(t, p)
     with open(filename, "w") as f:
         for line in data:
-            f.write(f"{line:016x}\n")
+            f.write(f"{line:016x}\n")  # noqa: E231
 
 
-def write_a0(filename: str, t: list, p: list, legacy=None):
+def write_a0(filename: str, t: list, p: list, legacy=None, **kwargs):
     events = _consolidate_events(t, p)
     data = np.empty((2 * events.size,), dtype=np.uint32)
     data[0::2] = events & 0xFFFFFFFF
     data[1::2] = events >> 32
     with open(filename, "w") as f:
         for line in data:
-            f.write(f"{line:08x}\n")
+            f.write(f"{line:08x}\n")  # noqa: E231
 
 
-def write_a1(filename: str, t: list, p: list, legacy: bool = False):
+def write_a1(filename: str, t: list, p: list, legacy: bool = False, **kwargs):
     events = _consolidate_events(t, p)
     with open(filename, "wb") as f:
         for line in events:

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ requirements = [
     "psutil",
     "pyserial",
     "numpy",
+    "fpfind @ git+https://github.com/s-fifteen-instruments/fpfind.git ; python_version >= '3.8'",  # noqa: E501
 ]
 requirements_dev = [
     "pre-commit",


### PR DESCRIPTION
Enables flag to ignore rollover events which are artifacts generated by the timestamp to track epoch changes during fast mode, and not removed by readevents. This feature enables timestamps running on fast mode to report the correct count rates, even if the average event rate is much lower than the epoch switchover rate during fast mode.

fpfind has been added as a Python 3.8 dependency, whose timestamp parsing functionality is kept more updated. Feature has been backported from fpfind to support Python 3.6 and 3.7.

This is a breaking change, since with the previous implementation, TDC2 running in fast mode at low event rates will report these rollover events as extra counts.