### PR TITLE
Drop Python 3.6 and migrate to pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ The library can be uninstalled with,
 pip uninstall S15lib
 ```
 
-For older versions of Python, see the relevant commit / version to install below:
+For older versions of Python, see the relevant last supported version:
 
-* Python 3.6: `cf1487991b8f318b27d95ccdd0f5c09fec6b6ec1`
+* Python 3.6 @ [v0.2.0](https://github.com/s-fifteen-instruments/pyS15/releases/tag/v0.2.0): `pip install git+https://github.com/s-fifteen-instruments/pyS15.git@v0.2.0`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ S15lib is a Python package for controlling [S-Fifteen instruments](https://s-fif
 
 ## Installation
 
-[Python](https://www.python.org) 3.6+ is required.
+[Python](https://www.python.org) 3.7+ is required.
 Install the package directly with
 
 ```
@@ -28,6 +28,10 @@ The library can be uninstalled with,
 ```
 pip uninstall S15lib
 ```
+
+For older versions of Python, see the relevant commit / version to install below:
+
+* Python 3.6: `cf1487991b8f318b27d95ccdd0f5c09fec6b6ec1`
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,40 @@
 [build-system]
 requires = ["setuptools", "wheel", "numpy"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "S15lib"
+version = "0.2.0"
+description = "S-Fifteen Python Library"
+authors = [
+    { name = "Mathias Seidler" },
+]
+maintainers = [
+    { name = "S-Fifteen Instruments" },
+]
+readme = "README.md"
+requires-python = ">=3.7"
+dependencies = [
+    "psutil",
+    "pyserial",
+    "numpy",
+    "fpfind; python_version >= '3.8'",  # noqa: E501
+]
+dynamic = ["license"]  # using legacy setup.py assignment as workaround
+#license = { text = "MIT" }  # syntax for setuptools < 77 (Python <=3.8), Feb 2026 deprecation
+#license = "MIT"  # supported only in setuptools >=77 (Python >=3.9)
+
+[project.optional-dependencies]
+dev = [
+    "pre-commit",
+    "Cython",
+]
+apps = [
+    "PyQt5",
+    "Pyqtgraph",
+    "configargparse",
+]
+
+[tool.setuptools.packages.find]
+include = ["S15lib*"]
+namespaces = false

--- a/setup.py
+++ b/setup.py
@@ -7,23 +7,6 @@ import sysconfig
 import numpy as np
 import setuptools
 
-requirements = [
-    "psutil",
-    "pyserial",
-    "numpy",
-    "fpfind; python_version >= '3.8'",  # noqa: E501
-]
-requirements_dev = [
-    "pre-commit",
-    "Cython",
-]
-requirements_apps = [
-    "PyQt5",
-    "Pyqtgraph",
-    "configargparse",
-]
-
-
 # Use C compiler as specified in env, or system's default, for compiling delta.so
 # Necessary on portable Python built with other compilers, e.g. gcc/clang
 #
@@ -114,20 +97,7 @@ if __name__ == "__main__":
     config["CC"], config["LDSHARED"] = get_compiler(config, os.environ)
 
     setuptools.setup(
-        name="S15lib",
-        version="0.2.0",
-        description="S-Fifteen Python Library",
-        url="https://s-fifteen.com/",
-        author="Mathias Seidler;",
-        author_email="",
         license="MIT",
-        packages=setuptools.find_packages(),
-        install_requires=requirements,
-        extras_require={
-            "dev": requirements_dev,
-            "apps": requirements_apps,
-        },
-        python_requires=">=3.6",
         ext_modules=[
             setuptools.Extension(
                 name="S15lib.g2lib.delta",


### PR DESCRIPTION
Library previously defines metadata in setup.py, which was appropriate for setuptools pre-PEP518 when pyproject.toml was not specified. Modern Python and tooling have since moved on to pyproject.toml, and is also required for publishing metadata in PyPI.

A workaround involves duplicating metadata in both pyproject.toml and setup.py, which is (1) error-prone, and (2) pointless since some subpackages of S15lib actually no longer supports Python 3.6 due to the use of Python 3.7+ functionality (e.g. dataclasses).

Section on which S15lib version to install has been added to assist old users of Python 3.6.